### PR TITLE
Custom icon image, put stuff behind prefs

### DIFF
--- a/src/assets/alert.svg
+++ b/src/assets/alert.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="28" height="28" xmlns="http://www.w3.org/2000/svg">
+  <path fill="context-fill" fill-opacity="context-fill-opacity" d="M27.386 22.024L17.48 2.212a4 4 0 0 0-7.156 0L.418 22.032a4 4 0 0 0 3.578 5.78h19.81a4 4 0 0 0 3.58-5.788zM11.902 7.812a2 2 0 1 1 4 0v8a2 2 0 1 1-4 0v-8zm2 16.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/>
+</svg>

--- a/src/privileged/FirefoxMonitor.css
+++ b/src/privileged/FirefoxMonitor.css
@@ -6,12 +6,9 @@
   display: none;
 }
 
-#fxmonitor-notification .popup-notification-icon,
 .fxmonitor-icon {
-  list-style-image: url("chrome://browser/skin/warning.svg");
-  fill: rgba(12, 12, 13, 0.6); /* Gray 90 a60 */
-  stroke: transparent;
-  -moz-context-properties: fill, stroke;
+  width: 16px;
+  height: 16px;
 }
 
 #fxmonitor-notification-anchor,

--- a/src/privileged/FirefoxMonitor.jsm
+++ b/src/privileged/FirefoxMonitor.jsm
@@ -292,7 +292,7 @@ this.FirefoxMonitor = {
             return this.getFormattedString(aKey, args);
           },
           getFirefoxMonitorURL: (aSiteName) => {
-            return `${this.FirefoxMonitorURL}/?breach=${aSiteName}&utm_source=firefox&utm_medium=popup`;
+            return `${this.FirefoxMonitorURL}/?breach=${encodeURIComponent(aSiteName)}&utm_source=firefox&utm_medium=popup`;
           },
         };
 

--- a/src/privileged/FirefoxMonitor.jsm
+++ b/src/privileged/FirefoxMonitor.jsm
@@ -45,6 +45,14 @@ this.FirefoxMonitor = {
   kBreachRefreshTimeoutPref: "extensions.fxmonitor.breachRefreshTimeout",
   kDefaultBreachRefreshTimeout: 60 * 60 * 1000,
 
+  // This is here for documentation, will be redefined to a pref getter
+  // using XPCOMUtils.defineLazyPreferenceGetter in delayedInit().
+  // The value of this property is used as the URL to which the user
+  // is directed when they click "Check Firefox Monitor".
+  FirefoxMonitorURL: null,
+  kFirefoxMonitorURLPref: "extensions.fxmonitor.FirefoxMonitorURL",
+  kDefaultFirefoxMonitorURL: "https://monitor.firefox.com",
+
   disable() {
     Preferences.set(this.kEnabledPref, false);
   },
@@ -145,6 +153,9 @@ this.FirefoxMonitor = {
 
     XPCOMUtils.defineLazyPreferenceGetter(this, "breachRefreshTimeout",
       this.kBreachRefreshTimeoutPref, this.kDefaultBreachRefreshTimeout);
+
+    XPCOMUtils.defineLazyPreferenceGetter(this, "FirefoxMonitorURL",
+      this.kFirefoxMonitorURLPref, this.kDefaultFirefoxMonitorURL);
 
     await this.loadStrings();
     await this.loadBreaches();
@@ -279,6 +290,9 @@ this.FirefoxMonitor = {
           },
           getFormattedString: (aKey, args) => {
             return this.getFormattedString(aKey, args);
+          },
+          getFirefoxMonitorURL: (aSiteName) => {
+            return `${this.FirefoxMonitorURL}/?breach=${aSiteName}&utm_source=firefox&utm_medium=popup`;
           },
         };
 

--- a/src/privileged/FirefoxMonitor.jsm
+++ b/src/privileged/FirefoxMonitor.jsm
@@ -275,6 +275,7 @@ this.FirefoxMonitor = {
         let img = doc.createElementNS(XUL_NS, "image");
         img.setAttribute("role", "button");
         img.classList.add(`${this.kNotificationID}-icon`);
+        img.style.listStyleImage = `url(${this.getURL("assets/alert.svg")})`;
         box2.appendChild(img);
         box.appendChild(box2);
         // TODO: Add a tooltip to the image once content is provided by UX.
@@ -386,8 +387,14 @@ this.FirefoxMonitor = {
 
     let n = win.PopupNotifications.show(
       browser, this.kNotificationID, "",
-      `${this.kNotificationID}-notification-anchor`, panelUI.primaryAction, panelUI.secondaryActions,
-      {persistent: true, hideClose: true, eventCallback: populatePanel});
+      `${this.kNotificationID}-notification-anchor`,
+      panelUI.primaryAction, panelUI.secondaryActions, {
+        persistent: true,
+        hideClose: true,
+        eventCallback: populatePanel,
+        popupIconURL: this.getURL("assets/alert.svg")
+      }
+    );
 
     Services.telemetry.scalarAdd("fxmonitor.doorhanger_shown", 1);
 

--- a/src/privileged/subscripts/PanelUI.jsm
+++ b/src/privileged/subscripts/PanelUI.jsm
@@ -50,8 +50,9 @@ PanelUI.prototype = {
       label: this.getFormattedString("fxmonitor.checkButton.label", [this.brandString]),
       accessKey: this.getString("fxmonitor.checkButton.accessKey"),
       callback: () => {
-        this.doc.defaultView.openTrustedLinkIn(
-          `https://monitor.firefox.com/?breach=${this.site.Name}`, "tab", { });
+        let win = this.doc.defaultView;
+        win.openTrustedLinkIn(
+          win.FirefoxMonitorUtils.getFirefoxMonitorURL(this.site.Name), "tab", { });
 
         Services.telemetry.scalarAdd("fxmonitor.check_btn_clicked", 1);
       },


### PR DESCRIPTION
This adds in the custom alert icon from the spec (https://mozilla.invisionapp.com/share/5KNEJ6VZFDQ#/screens).

This prevents us from being broken if someone removes the warning.svg in m-c. This also uses the fill/fill-opacity already set somewhere in browser styles so that we get good styling for free with the dark theme as well.

This PR also includes commits to put the Firefox Monitor URL, the breaches list URL, and breach refresh timeout behind prefs. It also adds our campaign URL params to the Firefox Monitor URL.