### PR TITLE
Add l10n.toml and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# flod as main contact for string changes
+src/locales/en-US/*.properties @flodolo

--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "."
+
+locales = []
+
+[env]
+    l = "{l10n_base}/src/locales/{locale}/"
+
+[[paths]]
+    reference = "src/locales/en-US/**"
+    l10n = "{l}**"


### PR DESCRIPTION
The l10n.toml can be used to perform checks using compare-locales (a Python packages). 

Example (you'll need the `it` localization in tree). Install compare-locales (3.3.0, since the latest has some issues)

`pip install compare-locales=3.3.0`

And run it from the root

`compare-locales l10n.toml . it --data json`